### PR TITLE
I've made the following changes:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules/
+.DS_Store
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+coverage/
+dist/
+build/
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "description": "This project is an MVP for a prompt generation application based on the specifications in `.github/copilot-instructions.md`. It allows users to create, manage, and use prompt templates, share them publicly, and duplicate existing public templates.",
+  "main": "playwright.config.js",
+  "scripts": {
+    "test": "./node_modules/.bin/playwright test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/koboriakira/prom-party.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/koboriakira/prom-party/issues"
+  },
+  "homepage": "https://github.com/koboriakira/prom-party#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "playwright": "^1.52.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,53 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'https://prom-party.netlify.app/',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    /* // Firefox や WebKit も必要に応じて有効化
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    */
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/tests/auth.spec.js
+++ b/tests/auth.spec.js
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentication', () => {
+  test('should navigate to Google login page when Login with Google is clicked', async ({ page }) => {
+    await page.goto('/'); // baseURL is set, so '/' accesses https://prom-party.netlify.app/
+
+    // Wait for the "Login with Google" button to be visible
+    const loginButton = page.locator('button:has-text("Login with Google")');
+    await expect(loginButton).toBeVisible({ timeout: 10000 }); // Set a longer timeout
+
+    // Click the login button
+    // Since this redirects to a Google page, use page.waitForNavigation or page.waitForURL
+    // However, as the page navigates to Google immediately after the click,
+    // use Promise.all to perform the click and wait for navigation simultaneously.
+    await Promise.all([
+      page.waitForNavigation({ timeout: 15000 }), // Wait for navigation to the Google page, longer timeout
+      loginButton.click(),
+    ]);
+
+    // Verify that the current URL contains Google's authentication-related domain
+    // Expect it to include accounts.google.com
+    expect(page.url()).toContain('accounts.google.com');
+
+    // Note: This test does not perform an actual login.
+    // It only verifies the correct navigation to the Google login page.
+  });
+
+  // TC1.2: Logout (Commented out or skipped as implementation is difficult at this stage)
+  // test('should show login button after logout', async ({ page }) => {
+  //   // Prerequisite: How to create a logged-in state is a challenge
+  //   // Example: Load a pre-existing login session or use a test API to set the login state
+  //   // await loginUser(page); // Placeholder login function
+
+  //   const logoutButton = page.locator('button:has-text("Logout")');
+  //   await expect(logoutButton).toBeVisible();
+  //   await logoutButton.click();
+
+  //   const loginButton = page.locator('button:has-text("Login with Google")');
+  //   await expect(loginButton).toBeVisible();
+  // });
+});


### PR DESCRIPTION
- Resolved the Google OAuth redirection issue. You will now be correctly redirected to the Netlify app (prom-party.netlify.app) after Google login. This involved guiding you to update Supabase OAuth redirect URI settings.
- Created a comprehensive set of normal-case test scenarios covering user authentication, template CRUD, prompt generation, template sharing, and public template usage.
- Introduced Playwright for E2E testing:
    - Set up Node.js and npm in the development environment.
    - Added Playwright and @playwright/test dependencies.
    - Created playwright.config.js and an initial test file (tests/auth.spec.js).
    - Implemented a test case to verify navigation to the Google login page.
    - Added .gitignore to exclude node_modules.
- The initial Playwright test for Google login page navigation passes successfully.