### PR TITLE
Refactor: Separate templates updated_at migration

### DIFF
--- a/supabase/migrations/0001_add_updated_at_to_templates.sql
+++ b/supabase/migrations/0001_add_updated_at_to_templates.sql
@@ -1,0 +1,18 @@
+-- Add updated_at column to templates table
+ALTER TABLE public.templates
+ADD COLUMN updated_at timestamp without time zone null default now();
+
+-- Function to update updated_at timestamp
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Trigger to update updated_at timestamp on templates table update
+CREATE TRIGGER update_templates_updated_at
+BEFORE UPDATE ON public.templates
+FOR EACH ROW
+EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
This commit refactors the previous schema modification for the `templates` table's `updated_at` column and trigger.

The changes have been moved from the initial schema file (`0000_initial_schema.sql`) into a new, dedicated migration file (`0001_add_updated_at_to_templates.sql`).

This separation improves the organization of database migrations, making it easier to manage schema changes incrementally.